### PR TITLE
SolidWorks: Adding Checkbox to toggle autorotation

### DIFF
--- a/ConfigDialog.qml
+++ b/ConfigDialog.qml
@@ -14,8 +14,8 @@ UM.Dialog
     width: 300 * Screen.devicePixelRatio
     minimumWidth: 300 * Screen.devicePixelRatio
 
-    height: 100 * Screen.devicePixelRatio
-    minimumHeight: 100 * Screen.devicePixelRatio
+    height: 120 * Screen.devicePixelRatio
+    minimumHeight: 120 * Screen.devicePixelRatio
 
     title: catalog.i18nc("@title:window", "Cura SolidWorks Plugin Configuration")
 

--- a/ConfigDialog.qml
+++ b/ConfigDialog.qml
@@ -84,6 +84,12 @@ UM.Dialog
                 }
             }
         }
+        Row {
+            CheckBox {
+                text: qsTr("Autorotate model to normed orientation")
+                checked: true
+            }
+        }
     }
 
     rightButtons: [


### PR DESCRIPTION
- [x] Adding the checkbox
- [ ] Setting by default to "True"
- [ ] Connecting setting with the reader